### PR TITLE
Update references for the move to milo-os

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-docker.yaml@v1.9.0
     with:
+      registry-organization: milo-os
       image-name: email-provider-loops
     secrets: inherit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ jobs:
       packages: write
     uses: datum-cloud/actions/.github/workflows/publish-kustomize-bundle.yaml@v1.9.0
     with:
-      bundle-name: ghcr.io/datum-cloud/email-provider-loops-kustomize
+      bundle-name: ghcr.io/milo-os/loops-provider-kustomize
       bundle-path: config
       image-overlays: config/base
-      image-name: ghcr.io/datum-cloud/email-provider-loops
+      image-name: ghcr.io/milo-os/loops-provider
       debug: true
     secrets: inherit
     

--- a/config/base/services/controller-manager/kustomization.yaml
+++ b/config/base/services/controller-manager/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - manager.yaml
 - metrics-service.yaml
 images:
-- name: ghcr.io/datum-cloud/email-provider-loops
+- name: ghcr.io/milo-os/loops-provider
   newTag: latest

--- a/config/base/services/controller-manager/manager.yaml
+++ b/config/base/services/controller-manager/manager.yaml
@@ -100,7 +100,7 @@ spec:
           - secretRef:
               name: loops-keys # MUST contain the key LOOPS_API_KEY
 
-        image: ghcr.io/datum-cloud/email-provider-loops:latest
+        image: ghcr.io/milo-os/loops-provider:latest
         name: controller-manager
         
         ports:

--- a/config/base/services/webhook/kustomization.yaml
+++ b/config/base/services/webhook/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 - webhook.yaml
 - webhook-service.yaml
 images:
-- name: ghcr.io/datum-cloud/email-provider-loops
+- name: ghcr.io/milo-os/loops-provider
   newTag: latest

--- a/config/base/services/webhook/webhook.yaml
+++ b/config/base/services/webhook/webhook.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: webhook
-          image: ghcr.io/datum-cloud/email-provider-loops:latest
+          image: ghcr.io/milo-os/loops-provider:latest
           imagePullPolicy: IfNotPresent
           args:
             - webhook


### PR DESCRIPTION
This repo recently moved from [datum-cloud](https://github.com/datum-cloud) to [milo-os](https://github.com/milo-os). Updates internal links and image references to reflect the new home.