### PR TITLE
fix: stop retry loop when newsletter membership already exists under a different name

### DIFF
--- a/internal/contact_controller.go
+++ b/internal/contact_controller.go
@@ -353,6 +353,22 @@ func (r *LoopsContactController) addToNewsLetterList(ctx context.Context, contac
 			log.Info("ContactGroupMembership already exists")
 			return false
 		}
+		if reason, alreadyMember := duplicateMembershipReason(err); alreadyMember {
+			// A user could already have access to the newsletter because of a
+			// previously created membership under a different name. This
+			// prevents the reconciler from endlessly retrying a create that
+			// Milo's webhook will always reject as a duplicate.
+			log.Info("Contact already a member of the newsletter group", "reason", reason)
+			meta.SetStatusCondition(&contact.Status.Conditions, metav1.Condition{
+				Type:               NewsLetterAddedCondition,
+				Status:             metav1.ConditionTrue,
+				Reason:             NewsLetterAddedReason,
+				Message:            "Contact already added to Newsletter list on email provider.",
+				LastTransitionTime: metav1.Now(),
+				ObservedGeneration: contact.GetGeneration(),
+			})
+			return false
+		}
 		log.Error(err, "Failed to create ContactGroupMembership")
 
 		meta.SetStatusCondition(&contact.Status.Conditions, metav1.Condition{
@@ -389,4 +405,27 @@ func (r *LoopsContactController) generateCgmName(
 	hashStr := fmt.Sprintf("%x", hash)
 
 	return fmt.Sprintf("%s-%s", contact.Name, hashStr)
+}
+
+// duplicateMembershipReason inspects an Invalid admission error from the
+// ContactGroupMembership webhook and reports whether it means the contact is
+// already a member of the group under a different ContactGroupMembership
+// name. This happens when a membership for the same ContactRef+ContactGroupRef
+// pair already exists (e.g. created by another controller), so the composite
+// uniqueness check in the webhook rejects our deterministically-named create
+// even though errors.IsAlreadyExists is false.
+func duplicateMembershipReason(err error) (string, bool) {
+	if !errors.IsInvalid(err) {
+		return "", false
+	}
+	statusErr, ok := err.(*errors.StatusError)
+	if !ok || statusErr.ErrStatus.Details == nil {
+		return "", false
+	}
+	for _, cause := range statusErr.ErrStatus.Details.Causes {
+		if cause.Type == metav1.CauseTypeFieldValueDuplicate {
+			return cause.Message, true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
Fixes an infinite reconcile/retry loop in LoopsContactController.addToNewsLetterList.

When a ContactGroupMembership already exists for a contact+group pair under a different name than the one we deterministically generate, Milo's webhook rejects the create with a 422 Invalid/FieldValueDuplicate error instead of AlreadyExists. 

We only handled AlreadyExists, so this case fell through to the generic error path, left NewsLetterAddedCondition as False, and returned an error — causing controller-runtime to requeue and repeat the same rejected create indefinitely.

Now we detect the FieldValueDuplicate cause, treat it as "already enrolled", mark NewsLetterAddedCondition True, and return no error, so the reconciler stops